### PR TITLE
Deepro dev

### DIFF
--- a/meddlr/data/transforms/transform.py
+++ b/meddlr/data/transforms/transform.py
@@ -21,6 +21,53 @@ NORMALIZER_REGISTRY.__doc__ = """
 Registry for normalizing images
 """
 
+def add_motion_corruption(
+    image: torch.Tensor,
+    nshots: int,
+    translation: Optional[RandomAffine] = None,
+    trajectory: str = "blocked",
+) -> torch.Tensor:
+    """
+    Simulate 2D motion for multi-shot Cartesian MRI.
+
+    This function supports two trajectories:
+    - 'blocked': Where each shot corresponds to a consecutive block of kspace.
+       (e.g. 1 1 2 2 3 3)
+    - 'interleaved': Where shots are interleaved (e.g. 1 2 3 1 2 3)
+
+    We assume the phase encode direction is left to right
+    (i.e. along width dimension).
+
+    TODO: Add support for sensitivity maps.
+
+    Args:
+        image: The complex-valued image. Shape [..., height, width].
+        nshots: The number of shots in the image.
+            This should be equivalent to ceil(phase_encode_dim / echo_train_length).
+        translation: This is the translation to augment images in the image
+            domain. This is either 'None' or 'RandomAffine' for now.
+        trajectory: One of 'interleaved' or 'consecutive'.
+
+    Returns:
+        A motion corrupted image.
+    """
+    kspace = torch.zeros_like(image)
+    offset = int(math.ceil(kspace.shape[-1] / nshots))
+
+    for shot in range(nshots):
+        motion_image = translation.get_transform(image).apply_image(image)
+        motion_kspace = F.fft2c(motion_image)
+        if trajectory == "blocked":
+            kspace[..., shot * offset : (shot + 1) * offset] = motion_kspace[
+                ..., shot * offset : (shot + 1) * offset
+            ]
+        elif trajectory == "interleaved":
+            kspace[..., shot::nshots] = motion_kspace[..., shot::nshots]
+        else:
+            raise ValueError(f"trajectory '{trajectory}' not supported.")
+
+    return kspace
+
 
 def build_normalizer(cfg):
     cfg = cfg.MODEL.NORMALIZER

--- a/meddlr/data/transforms/transform.py
+++ b/meddlr/data/transforms/transform.py
@@ -9,7 +9,6 @@ from fvcore.common.registry import Registry
 
 from meddlr.forward import SenseModel
 from meddlr.ops import complex as cplx
-from meddlr.transforms.functional import add_motion_corruption
 from meddlr.transforms.gen.spatial import RandomAffine
 from meddlr.utils import transforms as T
 

--- a/meddlr/data/transforms/transform.py
+++ b/meddlr/data/transforms/transform.py
@@ -23,7 +23,7 @@ Registry for normalizing images
 """
 
 
-def add_motion_corruption(
+def affine_transform(
     image: torch.Tensor,
     nshots: int,
     translation: Optional[RandomAffine] = None,
@@ -557,16 +557,16 @@ class MotionDataTransform:
             tfm_gen = RandomAffine(p=1.0, translate=self.translation, angle=self.angle)
             tfm_gen.seed(seed)
 
-            image = image.permute(0, 3, 1, 2)
+            image = image.permute(0, 3, 1, 2) # Shape: (B, 1, H, W)
 
-            motion_img = add_motion_corruption(
+            motion_img = affine_transform(
                 image=image,
                 nshots=self.nshots,
                 translation=tfm_gen,
                 trajectory=self.trajectory,
             )
 
-            motion_img = motion_img.permute(0, 2, 3, 1)
+            motion_img = motion_img.permute(0, 2, 3, 1) # Shape: (B, H, W, 1)
             sense = SenseModel(maps)
             kspace = sense(motion_img)
 

--- a/meddlr/transforms/functional/mri.py
+++ b/meddlr/transforms/functional/mri.py
@@ -6,7 +6,6 @@ import torch
 
 import meddlr.ops as F
 import meddlr.ops.complex as cplx
-from meddlr.transforms.gen.spatial import RandomAffine
 
 
 def add_even_odd_motion(

--- a/meddlr/transforms/functional/mri.py
+++ b/meddlr/transforms/functional/mri.py
@@ -42,49 +42,4 @@ def add_even_odd_motion(
     return aug_kspace
 
 
-def add_motion_corruption(
-    image: torch.Tensor,
-    nshots: int,
-    translation: Optional[RandomAffine] = None,
-    trajectory: str = "blocked",
-) -> torch.Tensor:
-    """
-    Simulate 2D motion for multi-shot Cartesian MRI.
 
-    This function supports two trajectories:
-    - 'blocked': Where each shot corresponds to a consecutive block of kspace.
-       (e.g. 1 1 2 2 3 3)
-    - 'interleaved': Where shots are interleaved (e.g. 1 2 3 1 2 3)
-
-    We assume the phase encode direction is left to right
-    (i.e. along width dimension).
-
-    TODO: Add support for sensitivity maps.
-
-    Args:
-        image: The complex-valued image. Shape [..., height, width].
-        nshots: The number of shots in the image.
-            This should be equivalent to ceil(phase_encode_dim / echo_train_length).
-        translation: This is the translation to augment images in the image
-            domain. This is either 'None' or 'RandomAffine' for now.
-        trajectory: One of 'interleaved' or 'consecutive'.
-
-    Returns:
-        A motion corrupted image.
-    """
-    kspace = torch.zeros_like(image)
-    offset = int(math.ceil(kspace.shape[-1] / nshots))
-
-    for shot in range(nshots):
-        motion_image = translation.get_transform(image).apply_image(image)
-        motion_kspace = F.fft2c(motion_image)
-        if trajectory == "blocked":
-            kspace[..., shot * offset : (shot + 1) * offset] = motion_kspace[
-                ..., shot * offset : (shot + 1) * offset
-            ]
-        elif trajectory == "interleaved":
-            kspace[..., shot::nshots] = motion_kspace[..., shot::nshots]
-        else:
-            raise ValueError(f"trajectory '{trajectory}' not supported.")
-
-    return kspace

--- a/tools/eval_net.py
+++ b/tools/eval_net.py
@@ -9,7 +9,7 @@ Example:
 import itertools
 import os
 from copy import deepcopy
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Sequence
 
 import pandas as pd
 import torch
@@ -218,7 +218,7 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
         and angle is None
         and translation is None
         and nshots is None
-        and trajectory == "None"
+        and trajectory == "none"
     ):
         transform_mri_dim = 2
         transform_angle = 0
@@ -228,9 +228,9 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
         if mri_dim is not None:
             transform_mri_dim = mri_dim
         if angle is not None:
-            transform_angle = angle
+            transform_angle = (-angle, angle)
         if translation is not None:
-            transform_translation = translation
+            transform_translation = (translation, translation)
         if nshots is not None:
             transform_nshots = nshots
         if trajectory is not None:
@@ -303,6 +303,11 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
             "dataset": dataset_name,
             "Noise Level": noise_level,
             "Motion Level": motion_level,
+            "Angle": str(angle),
+            "Translation": str(translation),
+            "Trajectory": trajectory,
+            "n-shots": str(nshots),
+            "MRI DIM": str(mri_dim),
             "weights": weights_basename,
             "rescaled": not skip_rescale,
         }
@@ -348,7 +353,7 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
             dataset_name,
             as_test=True,
             add_noise=noise_level > 0,
-            add_motion=include_motion != "false",
+            add_motion=(include_motion != "false" and data_transform is not None),
             data_transform=data_transform,
         )
 
@@ -512,34 +517,33 @@ if __name__ == "__main__":
     parser.add_argument(
         "--angle",
         default=None,
-        type=Optional[float],
+        type=float,
         help=("How much rotation angle should be used for motion corruption " "of the dataset"),
     )
 
     parser.add_argument(
         "--translation",
         default=None,
-        type=Optional[float],
+        type=float,
         help=("How much translation should be used for motion " "corruption of the dataset"),
     )
     parser.add_argument(
         "--nshots",
         default=None,
-        type=Optional[float],
+        type=int,
         help=("How many shots should be used for motion corruption " "of the dataset."),
     )
+
     parser.add_argument(
         "--trajectory",
         default="None",
-        choice=("None", "interleaved", "blocked"),
+        choices=("None", "interleaved", "blocked"),
         help=(
             "Chooses between interleaved or blocked shots for motion " "corruption of the dataset"
         ),
     )
 
-    parser.add_argument(
-        "--mri_dim", default=None, type=Optional[float], help=("Selects dimensionality number")
-    )
+    parser.add_argument("--mri_dim", default=None, type=int, help=("Selects dimensionality number"))
 
     # End of Arguments for 2D Motion Corruption of the Dataset
 

--- a/tools/eval_net.py
+++ b/tools/eval_net.py
@@ -194,6 +194,7 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
     angle = args.angle
     translation = args.translation
     nshots = args.nshots
+    padlike = args.pad_like.lower()
     trajectory = args.trajectory.lower()
 
     noise_arg = args.noise.lower()
@@ -219,12 +220,14 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
         and translation is None
         and nshots is None
         and trajectory == "none"
+        and padlike == "none"
     ):
         transform_mri_dim = 2
         transform_angle = 0
         transform_translation = 0
         transform_nshots = 0
         transform_trajectory = 0
+        transform_padlike = "none"
         if mri_dim is not None:
             transform_mri_dim = mri_dim
         if angle is not None:
@@ -233,8 +236,10 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
             transform_translation = (translation, translation)
         if nshots is not None:
             transform_nshots = nshots
-        if trajectory is not None:
+        if trajectory != "none":
             transform_trajectory = trajectory
+        if padlike != "none":
+            transform_padlike = padlike
         mask_func = build_mask_func(cfg.AUG_TRAIN)
         data_transform = T.MotionDataTransform(
             cfg,
@@ -246,6 +251,7 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
             mri_dim=transform_mri_dim,
             angle=transform_angle,
             translation=transform_translation,
+            pad_like=transform_padlike,
             trajectory=transform_trajectory,
         )
 
@@ -544,6 +550,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--mri_dim", default=None, type=int, help=("Selects dimensionality number"))
+
+    parser.add_argument(
+        "--pad_like",
+        default="None",
+        choices=("None", "MRAugment"),
+        help=("Specify pad like argument to Random Affine transformation"),
+    )
 
     # End of Arguments for 2D Motion Corruption of the Dataset
 

--- a/tools/eval_net.py
+++ b/tools/eval_net.py
@@ -307,7 +307,7 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
             "Translation": str(translation),
             "Trajectory": trajectory,
             "n-shots": str(nshots),
-            "MRI DIM": str(mri_dim),
+            "mri_dim": str(mri_dim),
             "weights": weights_basename,
             "rescaled": not skip_rescale,
         }
@@ -353,7 +353,7 @@ def eval(cfg, args, model, weights_basename, criterion, best_value):
             dataset_name,
             as_test=True,
             add_noise=noise_level > 0,
-            add_motion=(include_motion != "false" and data_transform is not None),
+            add_motion=(include_motion and data_transform is not None),
             data_transform=data_transform,
         )
 
@@ -518,32 +518,30 @@ if __name__ == "__main__":
         "--angle",
         default=None,
         type=float,
-        help=("How much rotation angle should be used for motion corruption " "of the dataset"),
+        help="How much rotation angle should be used for motion corruption of the dataset",
     )
 
     parser.add_argument(
         "--translation",
         default=None,
         type=float,
-        help=("How much translation should be used for motion " "corruption of the dataset"),
+        help="How much translation should be used for motion corruption of the dataset",
     )
     parser.add_argument(
         "--nshots",
         default=None,
         type=int,
-        help=("How many shots should be used for motion corruption " "of the dataset."),
+        help="How many shots should be used for motion corruption of the dataset.",
     )
 
     parser.add_argument(
         "--trajectory",
         default="None",
         choices=("None", "interleaved", "blocked"),
-        help=(
-            "Chooses between interleaved or blocked shots for motion " "corruption of the dataset"
-        ),
+        help= "Chooses between interleaved or blocked shots for motion corruption of the dataset",
     )
 
-    parser.add_argument("--mri_dim", default=None, type=int, help=("Selects dimensionality number"))
+    parser.add_argument("--mri_dim", default=None, type=int, help="Selects dimensionality number")
 
     # End of Arguments for 2D Motion Corruption of the Dataset
 


### PR DESCRIPTION
Fixes for motion corruption so that it's properly working within meddlr. Earlier, it turns out motion corruption was just obliterating the image instead of properly motion corrupting it. The specific changes that fixed it are in transform.py - essentially, conversion of image into something that the motion corruption method can handle was missing as well as proper conversion of the image into the kspace using SenseModel and permute. With these fixes, motion corruption does seem to be working properly now. 